### PR TITLE
Remove Google Analytics

### DIFF
--- a/data.html
+++ b/data.html
@@ -85,15 +85,5 @@
   
   <script src="js/highcharts.js"></script>
   <script src="js/charts.js"></script>
-
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-50550635-2', 'auto');
-    ga('send', 'pageview');
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -143,15 +143,5 @@
 	<script src="js/jquery.tooltipster.min.js"></script>
 	<script src="js/highcharts.js"></script>
 	<script src="js/script.js"></script>
-
-	<script>
-	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-	  ga('create', 'UA-50550635-2', 'auto');
-	  ga('send', 'pageview');
-	</script>
 </body>
 </html>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/